### PR TITLE
Storage errors handling

### DIFF
--- a/CacheStorage/Storages/FsStorage.go
+++ b/CacheStorage/Storages/FsStorage.go
@@ -70,9 +70,6 @@ func (storage *FsStorage) Download(key string) (*DownloadResult, error) {
 	}
 	defer file.Close()
 
-	if err != nil {
-		return nil, err
-	}
 	var buf = bytes.NewBuffer(make([]byte, 0, fileInfo.Size()))
 
 	timer.Start("read")

--- a/CacheStorage/Storages/S3Storage.go
+++ b/CacheStorage/Storages/S3Storage.go
@@ -147,15 +147,17 @@ func (storage *S3Storage) Download(key string) (*DownloadResult, error) {
 			switch awsErr.Code() {
 			case s3.ErrCodeNoSuchBucket:
 				log.Tracef("bucket %s does not exist", storage.bucket)
+				return nil, nil
 			case "NotFound":
 				fallthrough
 			case s3.ErrCodeNoSuchKey:
 				log.Tracef("object with key %s does not exist in bucket %s", key, storage.bucket)
+				return nil, nil
 			}
 		} else {
 			log.Debugf("failed to download for file %s, %s", key, err)
 		}
-		return nil, nil
+		return nil, err
 	}
 
 	var result = DownloadResult{

--- a/Commands/Wrapper/Helpers.go
+++ b/Commands/Wrapper/Helpers.go
@@ -3,6 +3,7 @@ package Wrapper
 import (
 	"crypto/sha1"
 	"fmt"
+	log "forklift/Lib/Logging/ConsoleLogger"
 	"forklift/Lib/Rustc"
 	"hash"
 	"io"
@@ -54,6 +55,9 @@ func checksum(path string, hash hash.Hash, root bool) {
 			checksum(filepath.Join(path, entry.Name()), hash, false)
 		} else {
 			var file, _ = os.Open(filepath.Join(path, entry.Name()))
+			if log.GetLevel() > log.DebugLevel {
+				log.Tracef("calculating checksum of %s, result %s", filepath.Join(path, entry.Name()), fmt.Sprintf("%x", hash.Sum(nil)))
+			}
 			io.Copy(hash, file)
 			file.Close()
 		}

--- a/Lib/Config/Config.go
+++ b/Lib/Config/Config.go
@@ -14,7 +14,8 @@ import (
 
 var AppConfig = ForkliftConfig{
 	Storage: ForkliftStorage{
-		Type: "null",
+		Type:     "null",
+		ReadOnly: false,
 	},
 	Compression: ForkliftCompression{
 		Type: "none",

--- a/Lib/Config/Models.go
+++ b/Lib/Config/Models.go
@@ -9,7 +9,8 @@ type ForkliftConfig struct {
 }
 
 type ForkliftStorage struct {
-	Type string
+	Type     string
+	ReadOnly bool
 }
 
 type ForkliftCache struct {


### PR DESCRIPTION
Handle 'unauthorised' storage errors that can be caused by attempting to overwrite an existing cache package